### PR TITLE
ci: add basic chart tests and CI

### DIFF
--- a/.ci/test-env.sh
+++ b/.ci/test-env.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+
+# ------------------------------------------------------------------------------
+# test-env.sh
+#
+# This script is used predominantly by CI in order to deploy a testing environment
+# for running the chart tests in this repository. The testing environment includes
+# a fully functional Kubernetes cluster, usually based on a local Kubernetes
+# distribution like Kubernetes in Docker (KIND).
+#
+# Note: Callers are responsible for cleaning up after themselves, the testing env
+#       created here can be torn down with `ktf environments delete --name <NAME>`.
+# ------------------------------------------------------------------------------
+
+# ------------------------------------------------------------------------------
+# Configuration
+# ------------------------------------------------------------------------------
+
+TEST_ENV_NAME="${TEST_ENV_NAME:-ochami-charts-tests}"
+if [[ -n $1 ]]
+then
+    if [[ "$1" == "cleanup" ]]
+    then
+        ktf environments delete --name "${TEST_ENV_NAME}"
+        exit $?
+    fi
+fi
+
+set -euo pipefail
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+cd "${SCRIPT_DIR}/.."
+KIND_VERSION="${KIND_VERSION:-v0.22.0}"
+KUBERNETES_VERSION="${KUBERNETES_VERSION:-1.31.3}"
+GATEWAY_API_VERSION="${GATEWAY_API_VERSION:-v1.2.0}"
+CHART_NAME="${CHART_NAME:-ingress}"
+OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+ARCH="$(uname -m | sed 's/x86_64/amd64/' | sed 's/aarch64/arm64/')"
+KTF_URL=https://github.com/Kong/kubernetes-testing-framework/releases/latest/download/ktf.${OS}.${ARCH}
+
+# ------------------------------------------------------------------------------
+# Setup Tools - Docker
+# ------------------------------------------------------------------------------
+
+# ensure docker command is accessible
+if ! command -v docker &> /dev/null
+then
+    echo "ERROR: docker command not found"
+    exit 10
+fi
+
+# ensure docker is functional
+docker info 1>/dev/null
+
+# ------------------------------------------------------------------------------
+# Setup Tools - Kind
+# ------------------------------------------------------------------------------
+
+# ensure kind command is accessible
+if ! command -v kind &> /dev/null
+then
+    go install sigs.k8s.io/kind@"${KIND_VERSION}"
+fi
+
+# ensure kind is functional
+kind version 1>/dev/null
+
+# ------------------------------------------------------------------------------
+# Setup Tools - KTF
+# ------------------------------------------------------------------------------
+
+# ensure ktf command is accessible
+if ! command -v ktf 1>/dev/null
+then
+    mkdir -p "${HOME}"/.local/bin
+    echo "Downloading KTF from ${KTF_URL}"
+    # grep location header to show the actual URL
+    curl -vL -o "${HOME}"/.local/bin/ktf "${KTF_URL}" 2>&1 | grep "location: https://github.com/Kong/kubernetes-testing-framework/releases/download/"
+    chmod +x "${HOME}"/.local/bin/ktf
+    export PATH="${HOME}/.local/bin:$PATH"
+fi
+
+# ensure kind is functional
+ktf 1>/dev/null
+
+# ------------------------------------------------------------------------------
+# Create Testing Environment
+# ------------------------------------------------------------------------------
+ktf environments create --name "${TEST_ENV_NAME}" --addon metallb --kubernetes-version "${KUBERNETES_VERSION}"
+
+kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=${GATEWAY_API_VERSION}" | kubectl apply -f -

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: daily
+  labels:
+  - github_actions

--- a/.github/workflows/chart-test.yaml
+++ b/.github/workflows/chart-test.yaml
@@ -1,0 +1,78 @@
+name: PR tests
+
+concurrency:
+  # Run only for most recent commit in PRs but for all tags and commits on main
+  # Ref: https://docs.github.com/en/actions/using-jobs/using-concurrency
+  group: ${{ github.workflow }}-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - lbnl/helm/**
+  workflow_dispatch: {}
+
+env:
+  KIND_VERSION: v0.25.0
+
+jobs:
+  lint-test:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chart-name:
+          - lbnl/helm
+        kubernetes-version:
+          - "1.30.6"
+          - "1.31.2"
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v4.2.0
+
+      - name: Add Helm repos
+        run: |
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.6.1
+
+      - name: Run chart-testing (lint)
+        run: ct lint --target-branch main --check-version-increment=false --chart-dirs lbnl --validate-maintainers=false
+
+      - name: Create test cluster
+        env:
+          KUBERNETES_VERSION: ${{ matrix.kubernetes-version }}
+          CHART_NAME: ${{ matrix.chart-name }}
+        run: ./.ci/test-env.sh
+
+      - name: Run ct install
+        run: ct install --target-branch main --charts ${{ matrix.chart-name}}
+
+      - name: Clean up test cluster
+        run: ./.ci/test-env.sh cleanup
+        if: always()
+
+  # Workaround to allow checking the matrix tests as required tests without adding the individual cases
+  # Ref: https://github.com/orgs/community/discussions/26822#discussioncomment-3305794
+  passed:
+    timeout-minutes: 30
+    runs-on: ubuntu-latest
+    needs:
+      - lint-test
+    if: always()
+    steps:
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: |
+          echo "Some jobs failed or were cancelled."
+          exit 1

--- a/lbnl/helm/templates/tests/jobs.yaml
+++ b/lbnl/helm/templates/tests/jobs.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-smd"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: "curl"
+      image: curlimages/curl
+      # This isn't entirely valid, since SMD apparently returns 200 to _any_ request, despite
+      # having a typical 404 handler. That's not really curl's fault though.
+      command:
+        - curl
+        - --fail
+        - "http://smd.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.smd.service.port }}/hsm/v2/State/Components"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-test-bss"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: OnFailure
+  containers:
+    - name: "{{ .Release.Name }}-curl"
+      image: curlimages/curl
+      command:
+        - curl
+        - --fail
+        - "http://bss.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.bss.service.port }}/boot/v1/hosts "


### PR DESCRIPTION
Add basic test Jobs to check that SMD and BSS accept requests.

Add CI to spawn a KinD cluster and use chart-testing to test the chart.